### PR TITLE
Add functions for summarizing the memory layout. 

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -9,6 +9,7 @@ Contributors:
 
 * Alexander Belchenko
 * Alex Mueller
+* Andrew Fernandes
 * Bernhard Leiner
 * Enoch H. Wexler
 * Heiko Henkelmann

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -37,6 +37,7 @@ They provide help if called incorrectly.
 .. include:: manual/part3-3.txt
 .. include:: manual/part3-4.txt
 .. include:: manual/part3-5.txt
+.. include:: manual/part3-6.txt
 
 Embedding into other projects
 *****************************

--- a/docs/manual/part2-4.txt
+++ b/docs/manual/part2-4.txt
@@ -71,3 +71,16 @@ This defaults to '0xFF', but it can be changed by the user like so::
     >>> print ih[0]       # prints 0xFF because this location is blank
     >>> ih.padding = 0x00 # change padding byte
     >>> print ih[0]       # prints 0x00 because this location is blank
+
+Summarizing the data chunks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+One of the more useful properties of HEX files is that they can specify data
+in discontinuous segments. There are two main methods to summarize which
+data addresses are occupied::
+
+    >>> ih.addresses()
+    >>> ih.segments()
+
+The first will return a list of occupied data addresses in sorted order. The
+second will return a list of ``xrange`` objects, in sorted order, representing
+contiguous segment chunks of occupied data addresses.

--- a/docs/manual/part3-6.txt
+++ b/docs/manual/part3-6.txt
@@ -1,0 +1,19 @@
+Script ``hexinfo.py``
+*********************
+This is a script to summarize a hex file's contents.
+
+This utility creates a YAML-formatted, human-readable
+summary ofa set of HEX files. It includes the file name,
+execution start address (if any), and the address ranges
+covered by the data (if any).
+
+::
+
+    hexinfo: summarize a hex file's contents.
+
+    Usage:
+        python hexinfo.py [options] FILE [ FILE ... ]
+
+    Options:
+        -h, --help              this help message.
+        -v, --version           version info.

--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -147,7 +147,7 @@ class IntelHex(object):
                 if not self._buf.get(addr, None) is None:
                     raise AddressOverlapError(address=addr, line=line)
                 self._buf[addr] = bin[i]
-                addr += 1   # FIXME: addr should be wrapped
+                addr += 1   # FIXME: addr should be wrapped 
                             # BUT after 02 record (at 64K boundary)
                             # and after 04 record (at 4G boundary)
 
@@ -292,7 +292,7 @@ class IntelHex(object):
     def _get_start_end(self, start=None, end=None, size=None):
         """Return default values for start and end if they are None.
         If this IntelHex object is empty then it's error to
-        invoke this method with both start and end as None.
+        invoke this method with both start and end as None. 
         """
         if (start,end) == (None,None) and self._buf == {}:
             raise EmptyIntelHexError
@@ -319,7 +319,7 @@ class IntelHex(object):
         return start, end
 
     def tobinarray(self, start=None, end=None, pad=_DEPRECATED, size=None):
-        ''' Convert this object to binary form as array. If start and end
+        ''' Convert this object to binary form as array. If start and end 
         unspecified, they will be inferred from the data.
         @param  start   start address of output bytes.
         @param  end     end address of output bytes (inclusive).
@@ -427,7 +427,7 @@ class IntelHex(object):
 
     def addresses(self):
         '''Returns all used addresses in sorted order.
-        @return         list of occupied data addresses in sorted order.
+        @return         list of occupied data addresses in sorted order. 
         '''
         aa = dict_keys(self._buf)
         aa.sort()
@@ -734,7 +734,7 @@ class IntelHex(object):
             self._buf[addr+i] = a[i]
 
     def getsz(self, addr):
-        """Get zero-terminated string from given address. Will raise
+        """Get zero-terminated string from given address. Will raise 
         NotEnoughDataError exception if a hole is encountered before a 0.
         """
         i = 0
@@ -813,7 +813,7 @@ class IntelHex(object):
                                   in overlapping region.
 
         @raise  TypeError       if other is not instance of IntelHex
-        @raise  ValueError      if other is the same object as self
+        @raise  ValueError      if other is the same object as self 
                                 (it can't merge itself)
         @raise  ValueError      if overlap argument has incorrect value
         @raise  AddressOverlapError    on overlapped data
@@ -959,7 +959,7 @@ class IntelHex16bit(IntelHex):
     def maxaddr(self):
         '''Get maximal address of HEX content in 16-bit mode.
 
-        @return         maximal address used in this object
+        @return         maximal address used in this object 
         '''
         aa = dict_keys(self._buf)
         if aa == []:
@@ -1133,7 +1133,7 @@ class Record(object):
 
     def eof():
         """Return End of File record as a string.
-        @return         String representation of Intel Hex EOF record
+        @return         String representation of Intel Hex EOF record 
         """
         return ':00000001FF'
     eof = staticmethod(eof)

--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -851,19 +851,22 @@ class IntelHex(object):
                     self.start_addr = other.start_addr
 
     def segments(self):
-        """Return a list of ordered xrange objects representing contiguous occupied data addresses."""
+        """Return a list of ordered tuple objects, representing contiguous occupied data addresses.
+        Each tuple has a length of two and follows the semantics of the range and xrange objects.
+        The second entry of the tuple is always an integer greater than the first entry.
+        """
         addresses = self.addresses()
         if not addresses:
             return []
         elif len(addresses) == 1:
-            return([xrange(addresses[0], addresses[0]+1)])
+            return([(addresses[0], addresses[0]+1)])
         adjacent_differences = [(b - a) for (a, b) in zip(addresses[:-1], addresses[1:])]
         breaks = [i for (i, x) in enumerate(adjacent_differences) if x > 1]
         endings = [addresses[b] for b in breaks]
         endings.append(addresses[-1])
         beginings = [addresses[b+1] for b in breaks]
         beginings.insert(0, addresses[0])
-        return [xrange(a, b+1) for (a, b) in zip(beginings, endings)]
+        return [(a, b+1) for (a, b) in zip(beginings, endings)]
 #/IntelHex
 
 

--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -849,6 +849,38 @@ class IntelHex(object):
                         'Starting addresses are different')
                 elif overlap == 'replace':
                     self.start_addr = other.start_addr
+
+
+    def segments(self):
+        """Return a list of (start, end) tuples of contiguous segments."""
+        addresses = self.addresses()
+        adjacent_differences = [(b - a) for (a, b) in zip(addresses[:-1], addresses[1:])]
+        breaks = [i for (i, x) in enumerate(adjacent_differences) if x > 1]
+        endings = [addresses[b] for b in breaks]
+        endings.append(addresses[-1])
+        beginings = [addresses[b+1] for b in breaks]
+        beginings.insert(0, addresses[0])
+        return [(a, b) for (a, b) in zip(beginings, endings)]
+
+    def info(self):
+        """Return a dict of information about current memory, using hex strings for addresses."""
+        info = {}
+        if self.start_addr:
+            keys = dict_keys(self.start_addr)
+            keys.sort()
+            if keys == ['CS','IP']:
+                entry = '0x{:04X}{:04X}'.format(self.start_addr['CS'], self.start_addr['IP'])
+            elif keys == ['EIP']:
+                entry = '0x{:08X}'.format(self.start_addr['EIP'])
+            info['entry'] = entry
+        segments = self.segments()
+        info['segments'] = [{ 'begin': '0x{:08X}'.format(a), 'end': '0x{:08X}'.format(b)} for (a, b) in segments]
+        return info
+
+    def json_info(self, indent=2):
+        """Return a JSON-formatted string representing the memory layout."""
+        import json
+        return json.dumps(self.info(), sort_keys=True, indent=indent)
 #/IntelHex
 
 

--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -147,7 +147,7 @@ class IntelHex(object):
                 if not self._buf.get(addr, None) is None:
                     raise AddressOverlapError(address=addr, line=line)
                 self._buf[addr] = bin[i]
-                addr += 1   # FIXME: addr should be wrapped 
+                addr += 1   # FIXME: addr should be wrapped
                             # BUT after 02 record (at 64K boundary)
                             # and after 04 record (at 4G boundary)
 
@@ -292,7 +292,7 @@ class IntelHex(object):
     def _get_start_end(self, start=None, end=None, size=None):
         """Return default values for start and end if they are None.
         If this IntelHex object is empty then it's error to
-        invoke this method with both start and end as None. 
+        invoke this method with both start and end as None.
         """
         if (start,end) == (None,None) and self._buf == {}:
             raise EmptyIntelHexError
@@ -319,7 +319,7 @@ class IntelHex(object):
         return start, end
 
     def tobinarray(self, start=None, end=None, pad=_DEPRECATED, size=None):
-        ''' Convert this object to binary form as array. If start and end 
+        ''' Convert this object to binary form as array. If start and end
         unspecified, they will be inferred from the data.
         @param  start   start address of output bytes.
         @param  end     end address of output bytes (inclusive).
@@ -427,7 +427,7 @@ class IntelHex(object):
 
     def addresses(self):
         '''Returns all used addresses in sorted order.
-        @return         list of occupied data addresses in sorted order. 
+        @return         list of occupied data addresses in sorted order.
         '''
         aa = dict_keys(self._buf)
         aa.sort()
@@ -734,7 +734,7 @@ class IntelHex(object):
             self._buf[addr+i] = a[i]
 
     def getsz(self, addr):
-        """Get zero-terminated string from given address. Will raise 
+        """Get zero-terminated string from given address. Will raise
         NotEnoughDataError exception if a hole is encountered before a 0.
         """
         i = 0
@@ -813,7 +813,7 @@ class IntelHex(object):
                                   in overlapping region.
 
         @raise  TypeError       if other is not instance of IntelHex
-        @raise  ValueError      if other is the same object as self 
+        @raise  ValueError      if other is the same object as self
                                 (it can't merge itself)
         @raise  ValueError      if overlap argument has incorrect value
         @raise  AddressOverlapError    on overlapped data
@@ -927,7 +927,7 @@ class IntelHex16bit(IntelHex):
     def maxaddr(self):
         '''Get maximal address of HEX content in 16-bit mode.
 
-        @return         maximal address used in this object 
+        @return         maximal address used in this object
         '''
         aa = dict_keys(self._buf)
         if aa == []:
@@ -1101,7 +1101,7 @@ class Record(object):
 
     def eof():
         """Return End of File record as a string.
-        @return         String representation of Intel Hex EOF record 
+        @return         String representation of Intel Hex EOF record
         """
         return ':00000001FF'
     eof = staticmethod(eof)

--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -850,37 +850,20 @@ class IntelHex(object):
                 elif overlap == 'replace':
                     self.start_addr = other.start_addr
 
-
     def segments(self):
-        """Return a list of (start, end) tuples of contiguous segments."""
+        """Return a list of ordered xrange objects representing contiguous occupied data addresses."""
         addresses = self.addresses()
+        if not addresses:
+            return []
+        elif len(addresses) == 1:
+            return([xrange(addresses[0], addresses[0]+1)])
         adjacent_differences = [(b - a) for (a, b) in zip(addresses[:-1], addresses[1:])]
         breaks = [i for (i, x) in enumerate(adjacent_differences) if x > 1]
         endings = [addresses[b] for b in breaks]
         endings.append(addresses[-1])
         beginings = [addresses[b+1] for b in breaks]
         beginings.insert(0, addresses[0])
-        return [(a, b) for (a, b) in zip(beginings, endings)]
-
-    def info(self):
-        """Return a dict of information about current memory, using hex strings for addresses."""
-        info = {}
-        if self.start_addr:
-            keys = dict_keys(self.start_addr)
-            keys.sort()
-            if keys == ['CS','IP']:
-                entry = '0x{:04X}{:04X}'.format(self.start_addr['CS'], self.start_addr['IP'])
-            elif keys == ['EIP']:
-                entry = '0x{:08X}'.format(self.start_addr['EIP'])
-            info['entry'] = entry
-        segments = self.segments()
-        info['segments'] = [{ 'begin': '0x{:08X}'.format(a), 'end': '0x{:08X}'.format(b)} for (a, b) in segments]
-        return info
-
-    def json_info(self, indent=2):
-        """Return a JSON-formatted string representing the memory layout."""
-        import json
-        return json.dumps(self.info(), sort_keys=True, indent=indent)
+        return [xrange(a, b+1) for (a, b) in zip(beginings, endings)]
 #/IntelHex
 
 

--- a/intelhex/test.py
+++ b/intelhex/test.py
@@ -766,31 +766,42 @@ class TestIntelHex(TestIntelHexBase):
         # test that address segments are correctly summarized
         ih = IntelHex()
         sg = ih.segments()
-        self.assertIsInstance(sg, list)
+        self.assertTrue(isinstance(sg, list))
         self.assertEquals(len(sg), 0)
         ih[0x100] = 0
         sg = ih.segments()
-        self.assertIsInstance(sg, list)
+        self.assertTrue(isinstance(sg, list))
         self.assertEquals(len(sg), 1)
-        self.assertIsInstance(sg[0], xrange)
-        self.assertEquals(min(sg[0]), 0x100)
-        self.assertEquals(max(sg[0]), 0x100)
-        ih[0x101] = 1
-        sg = ih.segments()
-        self.assertIsInstance(sg, list)
-        self.assertEquals(len(sg), 1)
+        self.assertTrue(isinstance(sg[0], tuple))
+        self.assertTrue(len(sg[0]) == 2)
+        self.assertTrue(sg[0][0] < sg[0][1])
         self.assertEquals(min(sg[0]), 0x100)
         self.assertEquals(max(sg[0]), 0x101)
+        ih[0x101] = 1
+        sg = ih.segments()
+        self.assertTrue(isinstance(sg, list))
+        self.assertEquals(len(sg), 1)
+        self.assertTrue(isinstance(sg[0], tuple))
+        self.assertTrue(len(sg[0]) == 2)
+        self.assertTrue(sg[0][0] < sg[0][1])
+        self.assertEquals(min(sg[0]), 0x100)
+        self.assertEquals(max(sg[0]), 0x102)
         ih[0x200] = 2
         ih[0x201] = 3
         ih[0x202] = 4
         sg = ih.segments()
-        self.assertIsInstance(sg, list)
+        self.assertTrue(isinstance(sg, list))
         self.assertEquals(len(sg), 2)
+        self.assertTrue(isinstance(sg[0], tuple))
+        self.assertTrue(len(sg[0]) == 2)
+        self.assertTrue(sg[0][0] < sg[0][1])
+        self.assertTrue(isinstance(sg[1], tuple))
+        self.assertTrue(len(sg[1]) == 2)
+        self.assertTrue(sg[1][0] < sg[1][1])
         self.assertEquals(min(sg[0]), 0x100)
-        self.assertEquals(max(sg[0]), 0x101)
+        self.assertEquals(max(sg[0]), 0x102)
         self.assertEquals(min(sg[1]), 0x200)
-        self.assertEquals(max(sg[1]), 0x202)
+        self.assertEquals(max(sg[1]), 0x203)
         pass
 
 class TestIntelHexLoadBin(TestIntelHexBase):

--- a/intelhex/test.py
+++ b/intelhex/test.py
@@ -762,6 +762,36 @@ class TestIntelHex(TestIntelHexBase):
         self.assertEquals((0,9), ih._get_start_end(start=0, size=10))
         self.assertEquals((1,10), ih._get_start_end(end=10, size=10))
 
+    def test_segments(self):
+        # test that address segments are correctly summarized
+        ih = IntelHex()
+        sg = ih.segments()
+        self.assertIsInstance(sg, list)
+        self.assertEquals(len(sg), 0)
+        ih[0x100] = 0
+        sg = ih.segments()
+        self.assertIsInstance(sg, list)
+        self.assertEquals(len(sg), 1)
+        self.assertIsInstance(sg[0], xrange)
+        self.assertEquals(min(sg[0]), 0x100)
+        self.assertEquals(max(sg[0]), 0x100)
+        ih[0x101] = 1
+        sg = ih.segments()
+        self.assertIsInstance(sg, list)
+        self.assertEquals(len(sg), 1)
+        self.assertEquals(min(sg[0]), 0x100)
+        self.assertEquals(max(sg[0]), 0x101)
+        ih[0x200] = 2
+        ih[0x201] = 3
+        ih[0x202] = 4
+        sg = ih.segments()
+        self.assertIsInstance(sg, list)
+        self.assertEquals(len(sg), 2)
+        self.assertEquals(min(sg[0]), 0x100)
+        self.assertEquals(max(sg[0]), 0x101)
+        self.assertEquals(min(sg[1]), 0x200)
+        self.assertEquals(max(sg[1]), 0x202)
+        pass
 
 class TestIntelHexLoadBin(TestIntelHexBase):
 

--- a/scripts/hexinfo.py
+++ b/scripts/hexinfo.py
@@ -33,7 +33,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""Summarize the information in a hex file my printing the execution
+"""Summarize the information in a hex file by printing the execution
         start address (if any), and the address ranges covered by the
         data (if any), in YAML format.
 """

--- a/scripts/hexinfo.py
+++ b/scripts/hexinfo.py
@@ -72,7 +72,7 @@ def summarize_yaml(fname):
     if segments:
         print("{:s}data:".format(INDENT))
         for s in segments:
-            print("{:s}{:s}{{ first: 0x{:08X}, last: 0x{:08X}, length: 0x{:08X} }}".format(INDENT, INLIST, min(s), max(s), len(s)))
+            print("{:s}{:s}{{ first: 0x{:08X}, last: 0x{:08X}, length: 0x{:08X} }}".format(INDENT, INLIST, s[0], s[1]-1, s[1]-s[0]))
     print("")
 
 def main(argv=None):

--- a/scripts/hexinfo.py
+++ b/scripts/hexinfo.py
@@ -1,0 +1,109 @@
+#!/usr/bin/python
+
+# Copyright (c) 2015 Andrew Fernandes <andrew@fernandes.org>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
+# that the following conditions are met:
+#
+# * Redistributions of source code must retain
+#   the above copyright notice, this list of conditions
+#   and the following disclaimer.
+# * Redistributions in binary form must reproduce
+#   the above copyright notice, this list of conditions
+#   and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of the author nor the names
+#   of its contributors may be used to endorse
+#   or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+# OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Summarize the information in a hex file my printing the execution
+        start address (if any), and the address ranges covered by the
+        data (if any), in YAML format.
+"""
+
+VERSION = '2.0'
+
+USAGE = '''hexinfo: summarize a hex file's contents.
+Usage:
+    python hexinfo.py [options] FILE [ FILE ... ]
+
+Options:
+    -h, --help              this help message.
+    -v, --version           version info.
+'''
+
+import sys
+
+INDENT = '  '
+INLIST = '- '
+
+def summarize_yaml(fname):
+    print("{:s}file: '{:s}'".format(INLIST, fname))
+    from intelhex import IntelHex
+    ih = IntelHex(fname)
+    if ih.start_addr:
+        keys = ih.start_addr.keys()
+        keys.sort()
+        if keys == ['CS','IP']:
+            entry = ih.start_addr['CS'] * 65536 + ih.start_addr['IP']
+        elif keys == ['EIP']:
+            entry = ih.start_addr['EIP']
+        else:
+            raise RuntimeError("unknown 'IntelHex.start_addr' found")
+        print("{:s}entry: 0x{:08X}".format(INDENT, entry))
+    segments = ih.segments()
+    if segments:
+        print("{:s}data:".format(INDENT))
+        for s in segments:
+            print("{:s}{:s}{{ first: 0x{:08X}, last: 0x{:08X}, length: 0x{:08X} }}".format(INDENT, INLIST, min(s), max(s), len(s)))
+    print("")
+
+def main(argv=None):
+    import getopt
+
+    if argv is None:
+        argv = sys.argv[1:]
+    try:
+        opts, args = getopt.gnu_getopt(argv, 'hv', ['help', 'version'])
+
+        for o,a in opts:
+            if o in ('-h', '--help'):
+                print(USAGE)
+                return 0
+            elif o in ('-v', '--version'):
+                print(VERSION)
+                return 0
+
+    except getopt.GetoptError:
+        e = sys.exc_info()[1]     # current exception
+        sys.stderr.write(str(e)+"\n")
+        sys.stderr.write(USAGE+"\n")
+        return 1
+
+    if len(args) < 1:
+        sys.stderr.write("ERROR: You should specify one or more files to summarize.\n")
+        sys.stderr.write(USAGE+"\n")
+        return 1
+
+    for fname in args:
+        summarize_yaml(fname)
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
When working with hex files, it's often useful to summarize whether or not they have an entry point, and what the contiguous segments are.

This pull request adds said functions, somewhat like the output of `srec_info` from the `srecord` project.

(A separate patch cleans up whitespace; my editor did it automatically, feel free to ignore it... I cherry picked the patches out, just in case.)

Thanks for a great project, by the way!