### PR TITLE
Extended IntelHex.dump() for variable width and optional padding

### DIFF
--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -753,16 +753,24 @@ class IntelHex(object):
         self.puts(addr, s)
         self._buf[addr+len(s)] = 0
 
-    def dump(self, tofile=None):
+    def dump(self, tofile=None, width=16, withpadding=False):
         """Dump object content to specified file object or to stdout if None.
         Format is a hexdump with some header information at the beginning,
         addresses on the left, and data on right.
 
-        @param  tofile        file-like object to dump to
+        @param  tofile          file-like object to dump to
+        @param  width           number of bytes per line (i.e. columns)
+        @param  withpadding     print padding character instead of '--'
+        @raise  ValueError      if width is not a positive integer
         """
 
+        if width < 1 or int(width) != width:
+            raise ValueError('width must be a positive integer.')
+        # The integer can be of float type - does not work with bit operations
+        width = int(width)
         if tofile is None:
             tofile = sys.stdout
+            
         # start addr possibly
         if self.start_addr is not None:
             cs = self.start_addr.get('CS')
@@ -780,17 +788,21 @@ class IntelHex(object):
             addresses.sort()
             minaddr = addresses[0]
             maxaddr = addresses[-1]
-            startaddr = int(minaddr>>4)*16
-            endaddr = int((maxaddr>>4)+1)*16
-            maxdigits = max(len(str(endaddr)), 4)
+            startaddr = (minaddr // width) * width
+            endaddr = ((maxaddr // width) + 1) * width
+            maxdigits = max(len(hex(endaddr)) - 2, 4)   # Less 2 to exclude '0x'
             templa = '%%0%dX' % maxdigits
-            range16 = range_l(16)
-            for i in range_g(startaddr, endaddr, 16):
+            rangewidth = range_l(width)
+            if withpadding:
+                pad = self.padding
+            else:
+                pad = None
+            for i in range_g(startaddr, endaddr, width):
                 tofile.write(templa % i)
                 tofile.write(' ')
                 s = []
-                for j in range16:
-                    x = self._buf.get(i+j)
+                for j in rangewidth:
+                    x = self._buf.get(i+j, pad)
                     if x is not None:
                         tofile.write(' %02X' % x)
                         if 32 <= x < 127:   # GNU less does not like 0x7F (128 decimal) so we'd better show it as dot

--- a/intelhex/test.py
+++ b/intelhex/test.py
@@ -960,17 +960,6 @@ class TestIntelHexGetPutString(TestIntelHexBase):
 
 class TestIntelHexDump(TestIntelHexBase):
 
-    def test_bad_width(self):
-        ih = IntelHex()
-        sio = StringIO()
-        badwidths = [0, -1, -10.5, 2.5]
-        for bw in badwidths:
-            self.assertRaisesMsg(ValueError, "width must be a positive integer.",
-                ih.dump, sio, bw)
-        badwidthtypes = ['', {}, [], sio]
-        for bwt in badwidthtypes:
-            self.assertRaisesMsg(TypeError, None, ih.dump, sio, bwt)
-
     def test_empty(self):
         ih = IntelHex()
         sio = StringIO()
@@ -983,53 +972,26 @@ class TestIntelHexDump(TestIntelHexBase):
         ih[1] = 0x34
         sio = StringIO()
         ih.dump(sio)
-        ih.dump(sio, 3) # width = 3
         self.assertEquals(
-            '0000  12 34 -- -- -- -- -- -- -- -- -- -- -- -- -- --  |.4              |\n'
-            '0000  12 34 --  |.4 |\n',  # width = 3
+            '0000  12 34 -- -- -- -- -- -- -- -- -- -- -- -- -- --  |.4              |\n',
             sio.getvalue())
-            
         ih[16] = 0x56
         ih[30] = 0x98
         sio = StringIO()
         ih.dump(sio)
-        ih.dump(sio, withpadding=True)
-        ih.dump(sio, 3) # width = 3
         self.assertEquals(
             '0000  12 34 -- -- -- -- -- -- -- -- -- -- -- -- -- --  |.4              |\n'
-            '0010  56 -- -- -- -- -- -- -- -- -- -- -- -- -- 98 --  |V             . |\n'
-            '0000  12 34 FF FF FF FF FF FF FF FF FF FF FF FF FF FF  |.4..............|\n'
-            '0010  56 FF FF FF FF FF FF FF FF FF FF FF FF FF 98 FF  |V...............|\n'
-            '0000  12 34 --  |.4 |\n'  # width = 3
-            '0003  -- -- --  |   |\n'
-            '0006  -- -- --  |   |\n'
-            '0009  -- -- --  |   |\n'
-            '000C  -- -- --  |   |\n'
-            '000F  -- 56 --  | V |\n'
-            '0012  -- -- --  |   |\n'
-            '0015  -- -- --  |   |\n'
-            '0018  -- -- --  |   |\n'
-            '001B  -- -- --  |   |\n'
-            '001E  98 -- --  |.  |\n',
+            '0010  56 -- -- -- -- -- -- -- -- -- -- -- -- -- 98 --  |V             . |\n',
             sio.getvalue())
 
     def test_minaddr_not_zero(self):
         ih = IntelHex()
-        ih[17] = 0x56
+        ih[16] = 0x56
         ih[30] = 0x98
         sio = StringIO()
         ih.dump(sio)
-        ih.dump(sio, withpadding=True)
-        ih.dump(sio, 3) # width = 3
         self.assertEquals(
-            '0010  -- 56 -- -- -- -- -- -- -- -- -- -- -- -- 98 --  | V            . |\n'
-            '0010  FF 56 FF FF FF FF FF FF FF FF FF FF FF FF 98 FF  |.V..............|\n'
-            '000F  -- -- 56  |  V|\n'  # width = 3
-            '0012  -- -- --  |   |\n'
-            '0015  -- -- --  |   |\n'
-            '0018  -- -- --  |   |\n'
-            '001B  -- -- --  |   |\n'
-            '001E  98 -- --  |.  |\n',
+            '0010  56 -- -- -- -- -- -- -- -- -- -- -- -- -- 98 --  |V             . |\n',
             sio.getvalue())
 
     def test_start_addr(self):
@@ -1049,6 +1011,60 @@ class TestIntelHexDump(TestIntelHexBase):
         self.assertEquals(
             'EIP = 0x12345678\n'
             '0000  12 34 -- -- -- -- -- -- -- -- -- -- -- -- -- --  |.4              |\n',
+            sio.getvalue())
+
+    def test_bad_width(self):
+        ih = IntelHex()
+        sio = StringIO()
+        badwidths = [0, -1, -10.5, 2.5]
+        for bw in badwidths:
+            self.assertRaisesMsg(ValueError, "width must be a positive integer.",
+                ih.dump, sio, bw)
+        badwidthtypes = ['', {}, [], sio]
+        for bwt in badwidthtypes:
+            self.assertRaisesMsg(TypeError, None, ih.dump, sio, bwt)
+
+    def test_simple_width3(self):
+        ih = IntelHex()
+        ih[0] = 0x12
+        ih[1] = 0x34
+        sio = StringIO()
+        ih.dump(sio, 3)
+        self.assertEquals(
+            '0000  12 34 --  |.4 |\n',
+            sio.getvalue())
+            
+        ih[16] = 0x56
+        ih[30] = 0x98
+        sio = StringIO()
+        ih.dump(sio, 3)
+        self.assertEquals(
+            '0000  12 34 --  |.4 |\n'
+            '0003  -- -- --  |   |\n'
+            '0006  -- -- --  |   |\n'
+            '0009  -- -- --  |   |\n'
+            '000C  -- -- --  |   |\n'
+            '000F  -- 56 --  | V |\n'
+            '0012  -- -- --  |   |\n'
+            '0015  -- -- --  |   |\n'
+            '0018  -- -- --  |   |\n'
+            '001B  -- -- --  |   |\n'
+            '001E  98 -- --  |.  |\n',
+            sio.getvalue())
+
+    def test_minaddr_not_zero_width3_padding(self):
+        ih = IntelHex()
+        ih[17] = 0x56
+        ih[30] = 0x98
+        sio = StringIO()
+        ih.dump(sio, 3, True)
+        self.assertEquals(
+            '000F  FF FF 56  |..V|\n'
+            '0012  FF FF FF  |...|\n'
+            '0015  FF FF FF  |...|\n'
+            '0018  FF FF FF  |...|\n'
+            '001B  FF FF FF  |...|\n'
+            '001E  98 FF FF  |...|\n',
             sio.getvalue())
 
 


### PR DESCRIPTION
IntelHex.dump() can now format the output in the given width (i.e.
number of columns). Any positive integer is accepted. Optionally, the
padding character can be used instead of '--'