### PR TITLE
<Makefile: Fix string quote in all>

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 PYTHON := python
 
 all:
-	@echo Available targets:
-	@echo  clean   - clean build directory
-	@echo  test    - run unittest
-	@echo  epydoc  - run epydoc to create API documentation
-	@echo  wininst - Windows installer for Python
-	@echo  docs    - build docs with ReST and Sphinx
-	@echo  wheel   - build wheel binary archive (see pip & wheel)
+	@echo   'Available targets:'
+	@echo   'clean   - clean build directory'
+	@echo   'test    - run unittest'
+	@echo   'epydoc  - run epydoc to create API documentation'
+	@echo   'wininst - Windows installer for Python'
+	@echo   'docs    - build docs with ReST and Sphinx'
+	@echo   'wheel   - build wheel binary archive (see pip & wheel)'
 
 .PHONY: clean test epydoc wininst docs
 


### PR DESCRIPTION
The ( & ) could be interpreted by the shell when running make

-  Without this patch:
$ make
Available targets:
clean - clean build directory
test - run unittest
epydoc - run epydoc to create API documentation
wininst - Windows installer for Python
docs - build docs with ReST and Sphinx
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `echo  wheel   - build wheel binary archive (see pip & wheel)' make: *** [Makefile:10: all] Error 1

- With this patch:
$ make
Available targets:
clean   - clean build directory
test    - run unittest
epydoc  - run epydoc to create API documentation
wininst - Windows installer for Python
docs    - build docs with ReST and Sphinx
wheel   - build wheel binary archive (see pip & wheel)