### PR TITLE
Add option to IntelHex.segments to split segments on alignment boundaries

### DIFF
--- a/intelhex/test.py
+++ b/intelhex/test.py
@@ -809,6 +809,26 @@ class TestIntelHex(TestIntelHexBase):
         self.assertEqual(max(sg[0]), 0x102)
         self.assertEqual(min(sg[1]), 0x200)
         self.assertEqual(max(sg[1]), 0x203)
+        ih[0x1fe] = 5
+        ih[0x1ff] = 6
+        sg = ih.segments(alignment=0x200)
+        self.assertTrue(isinstance(sg, list))
+        self.assertEqual(len(sg), 3)
+        self.assertTrue(isinstance(sg[0], tuple))
+        self.assertTrue(len(sg[0]) == 2)
+        self.assertTrue(sg[0][0] < sg[0][1])
+        self.assertTrue(isinstance(sg[1], tuple))
+        self.assertTrue(len(sg[1]) == 2)
+        self.assertTrue(sg[1][0] < sg[1][1])
+        self.assertTrue(isinstance(sg[2], tuple))
+        self.assertTrue(len(sg[2]) == 2)
+        self.assertTrue(sg[2][0] < sg[2][1])
+        self.assertEqual(min(sg[0]), 0x100)
+        self.assertEqual(max(sg[0]), 0x102)
+        self.assertEqual(min(sg[1]), 0x1fe)
+        self.assertEqual(max(sg[1]), 0x200)
+        self.assertEqual(min(sg[2]), 0x200)
+        self.assertEqual(max(sg[2]), 0x203)
         pass
 
 class TestIntelHexLoadBin(TestIntelHexBase):


### PR DESCRIPTION
In addition to finding contiguous occupied data addresses, it is often
useful to be able to further split these segments based on an integer
alignment, such as a flash page size or other block size. An optional
`alignment` parameter is added to IntelHex.segments which allows any
segments that span an integer multiple boundary of the alignment to
be split into multiple sub-segments. The semantics of the returned list
of ordered tuple objects is unchanged; that is, regardless of the given
alignment parameter, all addresses will be traversed as contiguous
segments.

I have also extended the `test_segments` portion to add support for testing the alignment parameter without changing any of the existing tests.